### PR TITLE
Deploy: MySQL, Redis 연결 및 개발용 초기 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### dev ###
+application-dev.properties

--- a/build.gradle
+++ b/build.gradle
@@ -31,16 +31,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-	// Security & JWT
+	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
 	// Database & Redis
 	runtimeOnly 'com.mysql:mysql-connector-j'
-//	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-//	implementation 'org.redisson:redisson-spring-boot-starter:3.23.1'
-//	implementation 'org.springframework.session:spring-session-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.23.1'
+	implementation 'org.springframework.session:spring-session-data-redis'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
@@ -49,12 +49,6 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
 	// Test Dependencies
-	runtimeOnly 'com.h2database:h2'
-	testImplementation 'com.h2database:h2'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testImplementation 'org.springframework.boot:spring-boot-test'
-	testImplementation 'org.springframework.boot:spring-boot-test-autoconfigure'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	// monitoring

--- a/src/main/java/com/knu/ddip/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/knu/ddip/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.knu.ddip.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/knu/ddip/common/config/RedisConfig.java
+++ b/src/main/java/com/knu/ddip/common/config/RedisConfig.java
@@ -1,0 +1,45 @@
+package com.knu.ddip.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${REDIS_HOST}")
+    private String host;
+    @Value("${REDIS_PORT}")
+    private int port;
+    @Value("${REDIS_PASSWORD}")
+    private String password;
+
+    @Bean
+    LettuceConnectionFactory connectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(
+                redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory());
+
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+        template.setKeySerializer(stringSerializer);
+        template.setValueSerializer(stringSerializer);
+        template.setHashKeySerializer(stringSerializer);
+        template.setHashValueSerializer(stringSerializer);
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/com/knu/ddip/common/config/SwaggerConfig.java
+++ b/src/main/java/com/knu/ddip/common/config/SwaggerConfig.java
@@ -1,0 +1,41 @@
+package com.knu.ddip.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    public static final String BEARER_AUTH = "BearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(createApiInfo())
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH))
+                .schemaRequirement(BEARER_AUTH, createSecurityScheme());
+    }
+
+    private Info createApiInfo() {
+        return new Info()
+                .title("DDIP 서비스 명세서")
+                .description("화이팅입니다!")
+                .version("0.0.1");
+    }
+
+    public SecurityScheme createSecurityScheme() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+        return securityScheme;
+    }
+}

--- a/src/main/java/com/knu/ddip/common/config/WebConfig.java
+++ b/src/main/java/com/knu/ddip/common/config/WebConfig.java
@@ -1,0 +1,25 @@
+package com.knu.ddip.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOriginPattern("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        config.addExposedHeader("Authorization");
+        config.setMaxAge(3600L);
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,22 @@
 spring.application.name=ddip
+spring.profiles.active=dev
+
+# MySQL
+spring.datasource.url=jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+spring.datasource.username=${MYSQL_USER}
+spring.datasource.password=${MYSQL_PASSWORD}
+
+# Redis
+spring.session.store-type=redis
+spring.data.redis.host=${REDIS_HOST}
+spring.data.redis.port=${REDIS_PORT}
+spring.data.redis.password=${REDIS_PASSWORD}
+
+# JPA
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=update
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect

--- a/src/test/java/com/knu/ddip/DBTest/MysqlConnectionTest.java
+++ b/src/test/java/com/knu/ddip/DBTest/MysqlConnectionTest.java
@@ -1,0 +1,27 @@
+package com.knu.ddip.DBTest;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.Statement;
+
+@SpringBootTest
+public class MysqlConnectionTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    void mysqlConnectionTest() throws Exception {
+        try (Connection connection = dataSource.getConnection();
+             Statement stmt = connection.createStatement()) {
+
+            Assertions.assertFalse(connection.isClosed(), "MySQL 연결 실패");
+            System.out.println("✅ MySQL 연결 성공: " + connection.getMetaData().getURL());
+        }
+    }
+}

--- a/src/test/java/com/knu/ddip/DBTest/RedisConnectionTest.java
+++ b/src/test/java/com/knu/ddip/DBTest/RedisConnectionTest.java
@@ -1,0 +1,25 @@
+package com.knu.ddip.DBTest;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@SpringBootTest
+public class RedisConnectionTest {
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Test
+    void redisConnectionTest() {
+        redisTemplate.opsForValue().set("connectionTest", "success");
+        String result = redisTemplate.opsForValue().get("connectionTest");
+
+        Assertions.assertEquals("success", result, "Redis 연결 실패");
+        System.out.println("Redis 연결 성공: " + result);
+
+        redisTemplate.delete("connectionTest");
+    }
+}

--- a/src/test/java/com/knu/ddip/DdipApplicationTests.java
+++ b/src/test/java/com/knu/ddip/DdipApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class DdipApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #8 

## 📚 배경
초기 개발을 위한 세팅이 필요

## 📝 작업 내용
- .gitignore에 개발 환경(dev)용 설정 파일 무시 추가
- Gradle 설정 파일 정리
- Spring Boot의 애플리케이션 속성 설정
- CORS 설정용 WebConfig 클래스 추가
- Redis 연동을 위한 RedisConfig 클래스 추가
- JPA 감사(Auditing) 기능을 위한 JpaAuditingConfig 클래스 추가
- Swagger 문서화를 위한 설정 클래스 추가
- Spring Boot 기본 테스트 추가
- MySQL 및 Redis 연결 확인을 위한 테스트 코드 작성

### 📸 스크린샷
<img width="257" height="478" alt="image" src="https://github.com/user-attachments/assets/4f3db4e3-ee45-44a4-871f-c0abbf5f9aeb" />
<img width="497" height="176" alt="image" src="https://github.com/user-attachments/assets/f7e1399e-22fb-482c-a1d1-328553a589b3" />
<img width="392" height="63" alt="image" src="https://github.com/user-attachments/assets/90f0f4ce-7dbe-42ad-bd75-7ffe033f7157" />

## 💬 리뷰 요구사항
없습니다.

## ✏ Git Close
close #8 
