### PR TITLE
Fix: 테스트 시 redisson 의존성 문제 해결

### DIFF
--- a/src/main/java/com/knu/ddip/common/config/RedisConfig.java
+++ b/src/main/java/com/knu/ddip/common/config/RedisConfig.java
@@ -17,11 +17,13 @@ import java.time.Duration;
 @Configuration
 public class RedisConfig {
 
-    @Value("${REDIS_HOST}")
+    @Value("${spring.data.redis.host}")
     private String host;
-    @Value("${REDIS_PORT}")
+
+    @Value("${spring.data.redis.port}")
     private int port;
-    @Value("${REDIS_PASSWORD}")
+
+    @Value("${spring.data.redis.password}")
     private String password;
 
     @Bean

--- a/src/main/java/com/knu/ddip/common/config/RedissonConfig.java
+++ b/src/main/java/com/knu/ddip/common/config/RedissonConfig.java
@@ -1,25 +1,28 @@
 package com.knu.ddip.common.config;
 
-import lombok.RequiredArgsConstructor;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
+import org.springframework.context.annotation.Profile;
 
-@RequiredArgsConstructor
+@Profile("!test")
 @Configuration
 public class RedissonConfig {
 
-    private final Environment env;
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
 
     @Bean
     public RedissonClient redissonClient() {
-        String host = env.getProperty("spring.data.redis.host", "localhost");
-        int port = env.getProperty("spring.data.redis.port", Integer.class, 6379);
-        String password = env.getProperty("spring.data.redis.password", "");
-
         Config config = new Config();
 
         config.useSingleServer()

--- a/src/main/java/com/knu/ddip/common/config/RedissonConfig.java
+++ b/src/main/java/com/knu/ddip/common/config/RedissonConfig.java
@@ -1,28 +1,25 @@
 package com.knu.ddip.common.config;
 
+import lombok.RequiredArgsConstructor;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
 
-@Profile("!test")
+@RequiredArgsConstructor
 @Configuration
 public class RedissonConfig {
 
-    @Value("${REDIS_HOST}")
-    private String host;
-
-    @Value("${REDIS_PORT}")
-    private int port;
-
-    @Value("${REDIS_PASSWORD}")
-    private String password;
+    private final Environment env;
 
     @Bean
     public RedissonClient redissonClient() {
+        String host = env.getProperty("spring.data.redis.host", "localhost");
+        int port = env.getProperty("spring.data.redis.port", Integer.class, 6379);
+        String password = env.getProperty("spring.data.redis.password", "");
+
         Config config = new Config();
 
         config.useSingleServer()

--- a/src/test/java/com/knu/ddip/DdipApplicationTests.java
+++ b/src/test/java/com/knu/ddip/DdipApplicationTests.java
@@ -6,9 +6,7 @@ import com.knu.ddip.config.TestEnvironmentConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("test")
 @SpringBootTest
 @ExtendWith({RedisTestContainerConfig.class, MySQLTestContainerConfig.class, TestEnvironmentConfig.class})
 class DdipApplicationTests {

--- a/src/test/java/com/knu/ddip/auth/infrastructure/repository/RedisTokenRepositoryImplIntegrationTest.java
+++ b/src/test/java/com/knu/ddip/auth/infrastructure/repository/RedisTokenRepositoryImplIntegrationTest.java
@@ -14,14 +14,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("test")
 @SpringBootTest
 @ExtendWith({RedisTestContainerConfig.class, MySQLTestContainerConfig.class, TestEnvironmentConfig.class})
 @Import(IntegrationTestConfig.class)

--- a/src/test/java/com/knu/ddip/config/IntegrationTestConfig.java
+++ b/src/test/java/com/knu/ddip/config/IntegrationTestConfig.java
@@ -2,7 +2,6 @@ package com.knu.ddip.config;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 
 
 @TestConfiguration

--- a/src/test/java/com/knu/ddip/config/RedisTestConfig.java
+++ b/src/test/java/com/knu/ddip/config/RedisTestConfig.java
@@ -11,7 +11,6 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.test.context.ActiveProfiles;
 
 @TestConfiguration
 public class RedisTestConfig {

--- a/src/test/java/com/knu/ddip/location/application/service/LocationServiceTest.java
+++ b/src/test/java/com/knu/ddip/location/application/service/LocationServiceTest.java
@@ -17,7 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +28,6 @@ import static com.knu.ddip.location.application.util.LocationKeyFactory.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@ActiveProfiles("test")
 @SpringBootTest
 @ExtendWith({RedisTestContainerConfig.class, MySQLTestContainerConfig.class, TestEnvironmentConfig.class})
 @Import(IntegrationTestConfig.class)

--- a/src/test/java/com/knu/ddip/location/infrastructure/repository/LocationReaderImplTest.java
+++ b/src/test/java/com/knu/ddip/location/infrastructure/repository/LocationReaderImplTest.java
@@ -7,14 +7,12 @@ import com.knu.ddip.config.TestEnvironmentConfig;
 import com.knu.ddip.location.exception.LocationNotFoundException;
 import com.knu.ddip.location.infrastructure.entity.LocationEntity;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -25,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-@ActiveProfiles("test")
 @Transactional
 @SpringBootTest
 @ExtendWith({RedisTestContainerConfig.class, MySQLTestContainerConfig.class, TestEnvironmentConfig.class})

--- a/src/test/java/com/knu/ddip/location/infrastructure/repository/LocationWriterImplTest.java
+++ b/src/test/java/com/knu/ddip/location/infrastructure/repository/LocationWriterImplTest.java
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -21,7 +20,6 @@ import java.util.stream.Collectors;
 import static com.knu.ddip.location.application.util.LocationKeyFactory.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("test")
 @Transactional
 @SpringBootTest
 @ExtendWith({RedisTestContainerConfig.class, MySQLTestContainerConfig.class, TestEnvironmentConfig.class})


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #25 


## 📚 배경
Redisson 테스트 시 프로덕션 코드의 Redisson 빈도 같이 생성되어 충돌이 발생한다고 이슈에 적어놨었는데, 그건 아니였고

테스트 프로퍼티가 설정되고(REDIS_HOST, REDIS_PORT, REDIS_PASSWORD), 테스트용 레디스가 실행되고 그 설정 정보가 저장되는데 이때 이게 spring.data.redis.host, spring.data.redis.port, spring.data.redis.password에 저장되어서 프로덕션단의 RedissonClient의 연결 오류가 났던 상황이었습니다.

결론적으로는 프로덕션단의 레디스 관련 코드들이 application-dev.properties들의 변수들을 참조하는데, 테스트 변수들이 application.properties의 값들을 변경해서 생긴 문제였습니다.

그런데 Redisson만 오류가 났던 이유는 LettuceConnectionFactory는 Lazy 연결로 실제로 필요할 때만 연결이 성립되서 오류가 나지 않고 나중에 테스트에서 사용될 때는 테스트용 LettuceConnectionFactory가 먼저 주입되서 문제가 없던 것이었습니다.

## 📝 작업 내용
* RedissonClient 생성 시 application.properties의 환경변수들을 참조하도록 변경하였습니다
* RedisConfig도 수정하였습니다

### 📸 스크린샷
x


## 💬 리뷰 요구사항
x


## ✏ Git Close
close #25
