### PR TITLE
Feat: 연동 테스트용 임시 jwt생성 로직 구현

### DIFF
--- a/src/main/java/com/knu/ddip/auth/business/service/OAuthLoginService.java
+++ b/src/main/java/com/knu/ddip/auth/business/service/OAuthLoginService.java
@@ -145,7 +145,7 @@ public class OAuthLoginService {
         return generateTokensForUser(user.getId(), deviceType);
     }
 
-    private JwtResponse generateTokensForUser(UUID userId, DeviceType deviceType) {
+    public JwtResponse generateTokensForUser(UUID userId, DeviceType deviceType) {
         UserEntityDto userEntityDto = userRepository.getById(userId);
         UserFactory.create(userEntityDto.getId(), userEntityDto.getEmail(),
                 userEntityDto.getNickname(), userEntityDto.getStatus());

--- a/src/main/java/com/knu/ddip/auth/domain/TokenType.java
+++ b/src/main/java/com/knu/ddip/auth/domain/TokenType.java
@@ -1,6 +1,5 @@
 package com.knu.ddip.auth.domain;
 
-//TODO: 추후 KAKAO 추가 예정
 public enum TokenType {
     ACCESS, REFRESH
 }

--- a/src/main/java/com/knu/ddip/user/business/dto/DummyRequest.java
+++ b/src/main/java/com/knu/ddip/user/business/dto/DummyRequest.java
@@ -1,0 +1,7 @@
+package com.knu.ddip.user.business.dto;
+
+public record DummyRequest(
+        String email,
+        String nickname
+) {
+}

--- a/src/main/java/com/knu/ddip/user/business/service/UserService.java
+++ b/src/main/java/com/knu/ddip/user/business/service/UserService.java
@@ -4,6 +4,7 @@ import com.knu.ddip.auth.business.dto.JwtResponse;
 import com.knu.ddip.auth.business.service.OAuthLoginService;
 import com.knu.ddip.auth.domain.DeviceType;
 import com.knu.ddip.auth.exception.OAuthBadRequestException;
+import com.knu.ddip.user.business.dto.DummyRequest;
 import com.knu.ddip.user.business.dto.SignupRequest;
 import com.knu.ddip.user.business.dto.UniqueMailResponse;
 import com.knu.ddip.user.business.dto.UserEntityDto;
@@ -70,5 +71,19 @@ public class UserService {
             userRepository.delete(user.getId());
             throw e;
         }
+    }
+
+    @Transactional
+    public JwtResponse dummyLogin(DummyRequest dummyRequest) {
+        UserEntityDto userEntityDto = userRepository.findOptionalByEmail(dummyRequest.email())
+                .map(user -> userRepository.getByEmail(dummyRequest.email()))
+                .orElseGet(() -> userRepository.save(
+                        dummyRequest.email(),
+                        dummyRequest.nickname(),
+                        UserStatus.ACTIVE.name()
+                ));
+        User user = userEntityDto.toDomain();
+
+        return oAuthLoginService.generateTokensForUser(user.getId(), DeviceType.PHONE);
     }
 }

--- a/src/main/java/com/knu/ddip/user/presentation/api/UserApi.java
+++ b/src/main/java/com/knu/ddip/user/presentation/api/UserApi.java
@@ -1,6 +1,7 @@
 package com.knu.ddip.user.presentation.api;
 
 import com.knu.ddip.auth.business.dto.JwtResponse;
+import com.knu.ddip.user.business.dto.DummyRequest;
 import com.knu.ddip.user.business.dto.SignupRequest;
 import com.knu.ddip.user.business.dto.UniqueMailResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,4 +25,9 @@ public interface UserApi {
             description = "메일이 사용 가능한지 조회한다. 휴면유저/탈퇴한 유저의 메일도 사용 불가.")
     ResponseEntity<UniqueMailResponse> checkEmailUniqueness(
             @RequestParam("v") String email);
+
+    @PostMapping("/dummy")
+    @Operation(summary = "[테스트용] 임시 로그인용 JWT 생성", description = "테스트를 위해 OAuth를 거치지 않고도 서버에서 사용 가능한 인증용 JWT를 생성한다. 주의: 만약 이미 존재하는 유저의 경우 닉네임이 입력한 email에 기반한 유저의 인증용 jwt가 생성되고, 닉네임은 입력한 닉네임이 아닌 기존의 닉네임으로 유지된다.")
+    ResponseEntity<JwtResponse> dummyLogin(
+            @RequestBody DummyRequest dummyRequest);
 }

--- a/src/main/java/com/knu/ddip/user/presentation/controller/UserController.java
+++ b/src/main/java/com/knu/ddip/user/presentation/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.knu.ddip.user.presentation.controller;
 
 import com.knu.ddip.auth.business.dto.JwtResponse;
+import com.knu.ddip.user.business.dto.DummyRequest;
 import com.knu.ddip.user.business.dto.SignupRequest;
 import com.knu.ddip.user.business.dto.UniqueMailResponse;
 import com.knu.ddip.user.business.service.UserService;
@@ -31,6 +32,12 @@ public class UserController implements UserApi {
             @RequestParam("v") String email) {
         UniqueMailResponse result = userService.checkEmailUniqueness(email);
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(result);
+    }
+
+    @Override
+    public ResponseEntity<JwtResponse> dummyLogin(DummyRequest dummyRequest) {
+        JwtResponse jwtResponse = userService.dummyLogin(dummyRequest);
+        return ResponseEntity.ok(jwtResponse);
     }
 
     //TODO: 로그아웃

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,7 @@ spring.data.redis.password=${REDIS_PASSWORD}
 # JPA
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.sql.init.mode=always
 spring.jpa.defer-datasource-initialization=true
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #34 

## 📚 배경
현재 jwt를 발급받기 위해서는 반드시 Oauth를 거쳐야하기 때문에, 프론트와의 원할한 연동 테스트를 위해 임시 jwt 생성기가 필요하다.

## 📝 작업 내용
- email과 닉네임 기반 jwt 생성 후 리턴 기능 추가
- 비즈니스 로직 구현
- 엔드포인트 구현

### 📸 스크린샷
<img width="920" height="703" alt="image" src="https://github.com/user-attachments/assets/6634d546-3607-4ed2-aa10-3f64d69e8043" />

## 💬 리뷰 요구사항
입력한 email과 nickname에 기반하여 만약 이미 존재하는 유저의 경우 nickname필드를 무시하고 email에 해당하는 유저의 accessToken과 refreshToken을 발급합니다.
만약, 존재하지 않는 유저의 경우 입력받은 두 필드를 기반으로 유저를 생성하여 두 토큰을 발급합니다.

## ✏ Git Close
close #34 
